### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 django-response-timeout
 ============================
 
-.. image:: https://pypip.in/v/django-response-timeout/badge.png
+.. image:: https://img.shields.io/pypi/v/django-response-timeout.svg
         :target: https://crate.io/packages/django-response-timeout
 
 .. image:: https://travis-ci.org/saulshanabrook/django-response-timeout.png


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20django-response-timeout))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `django-response-timeout`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.